### PR TITLE
BREAKING: change number-leading-zero to always

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = {
     "no-descending-specificity": null,
     "no-duplicate-selectors": true,
     "no-empty-source": null,
-    "number-leading-zero": "never",
+    "number-leading-zero": "always",
     "media-feature-name-no-unknown": [
       true,
       {


### PR DESCRIPTION
this is to be compliant with prettier formatting rules

Will break existing pipelines. projects can adjust easily using `stylelint --fix`